### PR TITLE
Proposal: removing default actions

### DIFF
--- a/lib/dictator/plug/authorize.ex
+++ b/lib/dictator/plug/authorize.ex
@@ -3,20 +3,12 @@ defmodule Dictator.Plug.Authorize do
 
   @behaviour Plug
 
-  @default_actions [:index, :show, :new, :create, :edit, :update, :delete]
-
   @impl Plug
   def init(opts), do: opts
 
   @impl Plug
   def call(conn, opts) do
-    allowed_actions = Keyword.get(opts, :only, @default_actions)
-
-    if conn.private.phoenix_action in allowed_actions do
-      authorize(conn, opts)
-    else
-      conn
-    end
+    authorize(conn, opts)
   end
 
   defp authorize(conn, opts) do


### PR DESCRIPTION
This is more of a discussion than a concrete PR
The plug currently assumes, by default, that only CRUD actions are
worthy of being checked.

This feels like risky behaviour to me.

Someone can easily, and unkowingly use this to authorize their
controller, noticing that it works the regular CRUD actions, but easily
miss that his one custom action is actually not checked at all

I would expect this to check everything by default, and at most,
`default_actions` being an opt-in, rather than an opt-out

In the short term, though, removing that altogether until a use case for
it comes along is a perfectly valid option

Also worth noting: after removing the logic for this, no tests failed at
all. Including the one that was suposed to be checking this exact
behaviour