### PR TITLE
Allow strategies for fetching the current user

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,9 +39,11 @@ And that's it! Just like that your users can edit, see and delete their own
     - [Limitting the actions to be authorized](#limitting-the-actions-to-be-authorized)
     - [Overriding the policy to be used](#overriding-the-policy-to-be-used)
     - [Overriding the current user key](#overriding-the-current-user-key)
+    - [Overriding the current user fetch strategy](#overriding-the-current-user-fetch-strategy)
   - [Configuration Options](#configuration-options)
     - [Setting a default repo](#setting-a-default-repo)
     - [Setting a default user key](#setting-a-default-current-user-key)
+    - [Setting the fetch strategy](#setting-the-fetch-strategy)
     - [Setting the unauthorized handler](#setting-the-unauthorized-handler)
 - [Contributing](#contributing)
 - [Setup](#setup)
@@ -322,6 +324,29 @@ defmodule ClientWeb.ThingController do
 end
 ```
 
+#### Overriding the current user fetch strategy
+
+By default, the plug will assume you want to search for the key set in the
+previous option in the `conn.assigns`. However, you may have it set in the
+session or want to use a custom strategy. You can change this behaviour by
+using the `fetch_strategy` option in the `plug` call. This will override the
+`fetch_strategy` option set in `config.exs`.
+
+There are two strategies available by default:
+
+- `Dictator.FetchStrategies.Assigns` - fetches the given key from `conn.assigns`
+- `Dictator.FetchStrategies.Session` - fetches the given key from the session
+
+```elixir
+defmodule ClientWeb.ThingController do
+  use ClientWeb, :controller
+
+  plug Dictator, fetch_strategy: Dictator.FetchStrategies.Session
+
+  # ...
+end
+```
+
 ### Configuration Options
 
 Dictator supports three options to be placed in `config/config.exs`:
@@ -366,6 +391,24 @@ by changing the config:
 
 ```elixir
 config :dictator, key: :current_company
+```
+
+The value set by the `key` option when plugging Dictator overrides this one.
+
+#### Setting the fetch strategy
+
+By default, the plug will assume you want to search for the key set in the
+previous option in the `conn.assigns`. However, you may have it set in the
+session or want to use a custom strategy. You can change this behaviour across
+the whole application by setting the `fetch_strategy` key in the config.
+
+There are two strategies available by default:
+
+- `Dictator.FetchStrategies.Assigns` - fetches the given key from `conn.assigns`
+- `Dictator.FetchStrategies.Session` - fetches the given key from the session
+
+```elixir
+config :dictator, fetch_strategy: Dictator.FetchStrategies.Session
 ```
 
 The value set by the `key` option when plugging Dictator overrides this one.

--- a/lib/dictator/fetch_strategies/assigns.ex
+++ b/lib/dictator/fetch_strategies/assigns.ex
@@ -1,0 +1,8 @@
+defmodule Dictator.FetchStrategies.Assigns do
+  @behaviour Dictator.FetchStrategy
+
+  @impl true
+  def fetch(conn, key) do
+    conn.assigns[key]
+  end
+end

--- a/lib/dictator/fetch_strategies/session.ex
+++ b/lib/dictator/fetch_strategies/session.ex
@@ -1,0 +1,8 @@
+defmodule Dictator.FetchStrategies.Session do
+  @behaviour Dictator.FetchStrategy
+
+  @impl true
+  def fetch(conn, key) do
+    Plug.Conn.get_session(conn, key)
+  end
+end

--- a/lib/dictator/fetch_strategy.ex
+++ b/lib/dictator/fetch_strategy.ex
@@ -1,0 +1,3 @@
+defmodule Dictator.FetchStrategy do
+  @callback fetch(Plug.Conn.t(), any()) :: map() | nil
+end

--- a/test/dictator/fetch_strategies/assigns_test.exs
+++ b/test/dictator/fetch_strategies/assigns_test.exs
@@ -1,0 +1,16 @@
+defmodule Dictator.FetchStrategies.AssignsTest do
+  use ExUnit.Case
+  use Plug.Test
+
+  alias Dictator.FetchStrategies.Assigns
+
+  describe "fetch/2" do
+    test "retrieves the key from the conn assigns" do
+      conn =
+        conn(:get, "/", nil)
+        |> assign(:current_user, %{id: 1})
+
+      assert %{id: 1} = Assigns.fetch(conn, :current_user)
+    end
+  end
+end

--- a/test/dictator/fetch_strategies/session_test.exs
+++ b/test/dictator/fetch_strategies/session_test.exs
@@ -1,0 +1,17 @@
+defmodule Dictator.FetchStrategies.SessionTest do
+  use ExUnit.Case
+  use Plug.Test
+
+  alias Dictator.FetchStrategies.Session
+
+  describe "fetch/2" do
+    test "retrieves the key from the session" do
+      conn =
+        conn(:get, "/", nil)
+        |> init_test_session(%{})
+        |> put_session(:current_user, %{id: 1})
+
+      assert %{id: 1} = Session.fetch(conn, :current_user)
+    end
+  end
+end


### PR DESCRIPTION
Why:

* Sometimes the current user is saved in the session.
* Sometimes the logic for fetching the current user is more complex.

This change addresses the need by:

* Allowing custom fetch strategies for fetching the current user.
* Adding two strategies by default: one for `conn.assigns` and the other
for the session