### PR TITLE
[Issue-21] - Fix: Wrong key for Ecto.Repo in the config files (:ecto instead of :ecto_repo)

### DIFF
--- a/lib/dictator/policies/ecto_schema.ex
+++ b/lib/dictator/policies/ecto_schema.ex
@@ -144,7 +144,7 @@ if Code.ensure_loaded?(Ecto) do
     Fetches the `Ecto.Repo` from the config. Intended for internal use.
     """
     def default_repo do
-      Dictator.Config.get(:ecto_repo)
+      Dictator.Config.get(:repo)
     end
   end
 end


### PR DESCRIPTION
**What's new**
 - [Issue-21](https://github.com/subvisual/dictator/issues/21) - Wrong key for Ecto.Repo in the config files (:ecto instead of :ecto_repo). Closes #21 .




**Danger: have breaking changes**