### PR TITLE
[Issue-24] - Add a handler for resources not found

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-elixir 1.9.4-otp-22
+elixir 1.8.0

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,1 @@
-elixir 1.8.0
+elixir 1.9.4-otp-22

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ And that's it! Just like that your users can edit, see and delete their own
     - [`Dictator.Policies.EctoSchema`](#dictator.policies.ectoschema)
     - [`Dictator.Policies.BelongsTo`](#dictator.policies.belongsto)
   - [Plug Options](#plug-options)
-    - [Limitting the actions to be authorized](#limitting-the-actions-to-be-authorized)
+    - [Limiting the actions to be authorized](#limiting-the-actions-to-be-authorized)
     - [Overriding the policy to be used](#overriding-the-policy-to-be-used)
     - [Overriding the current user key](#overriding-the-current-user-key)
     - [Overriding the current user fetch strategy](#overriding-the-current-user-fetch-strategy)
@@ -45,6 +45,7 @@ And that's it! Just like that your users can edit, see and delete their own
     - [Setting a default user key](#setting-a-default-current-user-key)
     - [Setting the fetch strategy](#setting-the-fetch-strategy)
     - [Setting the unauthorized handler](#setting-the-unauthorized-handler)
+    - [Setting the not found handler](#setting-the-not-found-handler)
 - [Contributing](#contributing)
 - [Setup](#setup)
 - [Other Projects](#other-projects)
@@ -274,7 +275,7 @@ also supported by `Dictator.Policies.BelongsTo`.
 - **resource\_key:** (optional, default: `:current_user`) - key to use in the
   conn.assigns to load the currently logged in resource.
 
-#### Limitting the actions to be authorized
+#### Limiting the actions to be authorized
 
 If you want to only limit authorization to a few actions you can use the `:only`
 or `:except` options when calling the plug in your controller:
@@ -333,8 +334,7 @@ previous option in the `conn.assigns`. However, you may have it set in the
 session or want to use a custom strategy. You can change this behaviour by
 using the `fetch_strategy` option in the `plug` call. This will override the
 `fetch_strategy` option set in `config.exs`.
-
-There are two strategies available by default:
+unauthorized
 
 - `Dictator.FetchStrategies.Assigns` - fetches the given key from `conn.assigns`
 - `Dictator.FetchStrategies.Session` - fetches the given key from the session
@@ -351,7 +351,7 @@ end
 
 ### Configuration Options
 
-Dictator supports three options to be placed in `config/config.exs`:
+Dictator supports four options to be placed in `config/config.exs`:
 
 - **repo** - default repo to be used by `Dictator.Policies.EctoSchema`. If not
   set, you need to define what repo to use in the policy through the `:repo`
@@ -360,7 +360,10 @@ Dictator supports three options to be placed in `config/config.exs`:
   current user in `conn.assigns`.
 - **unauthorized\_handler** (optional, default:
   `Dictator.UnauthorizedHandlers.Default`) - module to call to handle
-  unauthorisation errors.
+  unauthorisation errors. This error is sent when the policy returns `false`.
+- **not_found\_handler** (optional, default:
+  `Dictator.NotFoundHandlers.Default`) - module to call to handle
+  not found errors. This error is sent when the policy returns `nil` instead of `true` or `false`.
 
 #### Setting a default repo
 
@@ -426,6 +429,19 @@ You can also make use of the JSON API compatible
 
 ```elixir
 config :dictator, unauthorized_handler: MyUnauthorizedHandler
+```
+
+#### Setting the not found handler
+
+When a user tries to access a resource that does not exist, you may opt to return nil on the policy,
+and the not found handler will be called. By default this is `Dictator.NotFoundHandlers.Default`
+which sends a simple 404 with the body set to `"Object not found"`.
+
+You can also make use of the JSON API compatible
+`Dictator.NotFoundHandlers.JsonApi` or provide your own:
+
+```elixir
+config :dictator, not_found_handler: MyNotFoundHandler
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -334,7 +334,6 @@ previous option in the `conn.assigns`. However, you may have it set in the
 session or want to use a custom strategy. You can change this behaviour by
 using the `fetch_strategy` option in the `plug` call. This will override the
 `fetch_strategy` option set in `config.exs`.
-unauthorized
 
 - `Dictator.FetchStrategies.Assigns` - fetches the given key from `conn.assigns`
 - `Dictator.FetchStrategies.Session` - fetches the given key from the session

--- a/lib/dictator.ex
+++ b/lib/dictator.ex
@@ -57,7 +57,7 @@ defmodule Dictator do
 
   * `key`: Same as the `:key` parameter in the plug option section. The plug option takes precedence, meaning you can place it in a config and then override it in specific controllers or pipelines.
   * `unauthorized_handler`: Handler to be called when the user is not authorised to access the resource. Defaults to `Dictator.UnauthorizedHandlers.Default`.
-  * `not_found_handler`: Handler to be called when the object being accessed in the call does not exist. Defaults to `Dictator.UnauthorizedHandlers.Default`.
+  * `not_found_handler`: Handler to be called when the object being accessed in the call does not exist. Defaults to `Dictator.NotFoundHandlers.Default`.
   """
 
   @behaviour Plug

--- a/lib/dictator.ex
+++ b/lib/dictator.ex
@@ -153,7 +153,7 @@ defmodule Dictator do
   end
 
   defp not_found_handler do
-    Dictator.Config.get(:not_found_handler, Dictator.UnauthorizedHandlers.Default)
+    Dictator.Config.get(:not_found_handler, Dictator.NotFoundHandlers.Default)
   end
 
   defp requires_resource_load?(policy) do

--- a/lib/dictator.ex
+++ b/lib/dictator.ex
@@ -57,6 +57,7 @@ defmodule Dictator do
 
   * `key`: Same as the `:key` parameter in the plug option section. The plug option takes precedence, meaning you can place it in a config and then override it in specific controllers or pipelines.
   * `unauthorized_handler`: Handler to be called when the user is not authorised to access the resource. Defaults to `Dictator.UnauthorizedHandlers.Default`.
+  * `not_found_handler`: Handler to be called when the object being accessed in the call does not exist. Defaults to `Dictator.UnauthorizedHandlers.Default`.
   """
 
   @behaviour Plug
@@ -99,12 +100,19 @@ defmodule Dictator do
 
     params = %{params: conn.params, resource: resource, opts: opts}
 
-    if apply(policy, :can?, [user, action, params]) do
-      conn
-    else
-      unauthorized_handler = unauthorized_handler()
-      opts = unauthorized_handler.init(opts)
-      unauthorized_handler.call(conn, opts)
+    case apply(policy, :can?, [user, action, params]) do
+      true ->
+        conn
+
+      false ->
+        unauthorized_handler = unauthorized_handler()
+        opts = unauthorized_handler.init(opts)
+        unauthorized_handler.call(conn, opts)
+
+      nil ->
+        not_found_handler = not_found_handler()
+        opts = not_found_handler.init(opts)
+        not_found_handler.call(conn, opts)
     end
   end
 
@@ -142,6 +150,10 @@ defmodule Dictator do
 
   defp unauthorized_handler do
     Dictator.Config.get(:unauthorized_handler, Dictator.UnauthorizedHandlers.Default)
+  end
+
+  defp not_found_handler do
+    Dictator.Config.get(:not_found_handler, Dictator.UnauthorizedHandlers.Default)
   end
 
   defp requires_resource_load?(policy) do

--- a/lib/dictator/not_found_handlers/default.ex
+++ b/lib/dictator/not_found_handlers/default.ex
@@ -1,0 +1,24 @@
+defmodule Dictator.NotFoundHandlers.Default do
+  @moduledoc """
+  Basic not found handler to be called if none is provided.
+
+  When a user is tries to access to a resource and none is found, a not found handler is
+  called.  This is the most basic definition.  Simply returns
+  `404 NOT FOUND` with the text "Object not found".  No
+  content type or any other header is provided.
+  """
+
+  @behaviour Plug
+
+  import Plug.Conn
+
+  @impl Plug
+  def init(_), do: :ok
+
+  @impl Plug
+  def call(conn, _) do
+    conn
+    |> send_resp(:not_found, "Object not found")
+    |> halt()
+  end
+end

--- a/lib/dictator/not_found_handlers/json_api.ex
+++ b/lib/dictator/not_found_handlers/json_api.ex
@@ -1,0 +1,30 @@
+defmodule Dictator.NotFoundHandlers.JsonApi do
+  @moduledoc """
+  JSON API compatible not_found handler.
+
+  Configure your app to use this handler instead of
+  `Dictator.NotFoundHandlers.Default` by setting your `config/*.exs` to:
+
+  ```
+  config :dictator, not_found_handler: Dictator.NotFoundHandlers.JsonApi
+  ```
+
+  This handler sets the `content-type` header to `application/json` and sends
+  an empty body with the 404 status as the response.
+  """
+
+  @behaviour Plug
+
+  import Plug.Conn
+
+  @impl Plug
+  def init(_), do: :ok
+
+  @impl Plug
+  def call(conn, _) do
+    conn
+    |> put_resp_header("content-type", "application/json")
+    |> send_resp(:not_found, "{}")
+    |> halt()
+  end
+end

--- a/test/dictator/not_found_handlers/default_test.exs
+++ b/test/dictator/not_found_handlers/default_test.exs
@@ -1,0 +1,20 @@
+defmodule Dictator.NotFoundHandlers.DefaultTest do
+  use ExUnit.Case
+  use Plug.Test
+
+  alias Dictator.NotFoundHandlers.Default
+
+  describe "call/2" do
+    test "sets a 404 response" do
+      result = conn(:get, "/") |> Default.call([])
+
+      assert result.status == 404
+    end
+
+    test "sets a response body" do
+      result = conn(:get, "/") |> Default.call([])
+
+      assert is_binary(result.resp_body)
+    end
+  end
+end

--- a/test/dictator/not_found_handlers/json_api_test.exs
+++ b/test/dictator/not_found_handlers/json_api_test.exs
@@ -1,0 +1,28 @@
+defmodule Dictator.NotFoundHandlers.JsonApiTest do
+  use ExUnit.Case
+  use Plug.Test
+
+  alias Dictator.NotFoundHandlers.JsonApi
+
+  describe "call/2" do
+    test "sets a 404 response" do
+      result = conn(:get, "/") |> JsonApi.call([])
+
+      assert result.status == 404
+    end
+
+    test "sets an empty JSON response body" do
+      result = conn(:get, "/") |> JsonApi.call([])
+
+      assert result.resp_body == "{}"
+    end
+
+    test "sets a json content-type" do
+      result = conn(:get, "/") |> JsonApi.call([])
+
+      content_type = Enum.find(result.resp_headers, &(elem(&1, 0) == "content-type")) |> elem(1)
+
+      assert content_type == "application/json"
+    end
+  end
+end


### PR DESCRIPTION
** What's new **

[Issue-24](https://github.com/subvisual/dictator/issues/24) - Implemented a "not found" handler, with the possibility of the user configuring a custom not found handler. Closes #24 .

Previously, a policy only allowed a boolean response. The not found handler adds the possibility of returning nil within the can? function of a policy, and the dep will then call the not found handler instead of the unauthorized handler. 
Does not contain breaking changes.