### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,4 +1,4 @@
-name: Test Suite
+name: build
 
 on:
   push:
@@ -15,11 +15,11 @@ jobs:
     strategy:
       matrix:
         otp: ['22.2', '23.0']
-        elixir: ['1.8.2', '1.9.4', '1.10.3']
+        elixir: ['1.8.2', '1.9.4', '1.10.3', '1.11.3']
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-elixir@v1
+      - uses: erlef/setup-elixir@v1
         with:
           otp-version: ${{ matrix.otp }}
           elixir-version: ${{ matrix.elixir }}


### PR DESCRIPTION
`actions/setup-elixir` is now archive/deprecated and is causing builds
to fail due to Erlang SSL install errors.